### PR TITLE
Removal of master-slave language

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -138,8 +138,8 @@ class EmrConnection(AWSQueryConnection):
         return self.get_object('AddJobFlowSteps', params, RunJobFlowResponse)
 
     def run_jobflow(self, name, log_uri, ec2_keyname=None, availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version='0.18',
@@ -156,10 +156,10 @@ class EmrConnection(AWSQueryConnection):
         :param ec2_keyname: EC2 key used for the instances
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
         :type action_on_failure: str
@@ -182,7 +182,7 @@ class EmrConnection(AWSQueryConnection):
 
         # Instance args
         instance_params = self._build_instance_args(ec2_keyname, availability_zone,
-                                                    master_instance_type, slave_instance_type,
+                                                    main_instance_type, subordinate_instance_type,
                                                     num_instances, keep_alive, hadoop_version)
         params.update(instance_params)
 
@@ -258,11 +258,11 @@ class EmrConnection(AWSQueryConnection):
                 params['Steps.memeber.%s.%s' % (i+1, key)] = value
         return params
 
-    def _build_instance_args(self, ec2_keyname, availability_zone, master_instance_type,
-                             slave_instance_type, num_instances, keep_alive, hadoop_version):
+    def _build_instance_args(self, ec2_keyname, availability_zone, main_instance_type,
+                             subordinate_instance_type, num_instances, keep_alive, hadoop_version):
         params = {
-            'Instances.MasterInstanceType' : master_instance_type,
-            'Instances.SlaveInstanceType' : slave_instance_type,
+            'Instances.MainInstanceType' : main_instance_type,
+            'Instances.SubordinateInstanceType' : subordinate_instance_type,
             'Instances.InstanceCount' : num_instances,
             'Instances.KeepJobFlowAliveWhenNoSteps' : str(keep_alive).lower(),
             'Instances.HadoopVersion' : hadoop_version

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -109,7 +109,7 @@ class RDSConnection(AWSQueryConnection):
         return self.get_list('DescribeDBInstances', params, [('DBInstance', DBInstance)])
 
     def create_dbinstance(self, id, allocated_storage, instance_class,
-                          master_username, master_password, port=3306,
+                          main_username, main_password, port=3306,
                           engine='MySQL5.1', db_name=None, param_group=None,
                           security_groups=None, availability_zone=None,
                           preferred_maintenance_window=None,
@@ -146,13 +146,13 @@ class RDSConnection(AWSQueryConnection):
         :type engine: str
         :param engine: Name of database engine. Must be MySQL5.1 for now.
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
                                 Must be 1-15 alphanumeric characters, first
                                 must be a letter.
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-16 alphanumeric characters.
 
         :type port: int
@@ -213,8 +213,8 @@ class RDSConnection(AWSQueryConnection):
                   'AllocatedStorage' : allocated_storage,
                   'DBInstanceClass' : instance_class,
                   'Engine' : engine,
-                  'MasterUsername' : master_username,
-                  'MasterUserPassword' : master_password}
+                  'MainUsername' : main_username,
+                  'MainUserPassword' : main_password}
         if port:
             params['Port'] = port
         if db_name:
@@ -317,7 +317,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -339,8 +339,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/boto/rds/dbinstance.py
+++ b/boto/rds/dbinstance.py
@@ -36,7 +36,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -78,8 +78,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)

--- a/boto/rds/dbsnapshot.py
+++ b/boto/rds/dbsnapshot.py
@@ -33,7 +33,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -61,8 +61,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.